### PR TITLE
Suport more than one PPA

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,6 +4,8 @@ class apt {
 	$root = '/etc/apt'
 	$provider = '/usr/bin/apt-get'
 
+  package { "python-software-properties": }
+
 	file { "sources.list":
 		name => "${root}/sources.list",
 		ensure => present,

--- a/manifests/ppa.pp
+++ b/manifests/ppa.pp
@@ -3,18 +3,16 @@
 define apt::ppa(
 
 ) {
-	include apt
+    require apt
 
-    package { "python-software-properties": }
-
-    exec { "apt-update":
-        command     => "/usr/bin/apt-get update",
+    exec { "apt-update-${name}":
+        command     => "/usr/bin/aptitude update",
         refreshonly => true,
     }
 
-    exec { "/usr/bin/add-apt-repository ${name}":
-        require => Package["python-software-properties"],
-        notify => Exec["apt-update"]
+    exec { "add-apt-repository-${name}":
+        command => "/usr/bin/add-apt-repository ${name}",
+        notify  => Exec["apt-update-${name}"],
     }
 }
 


### PR DESCRIPTION
Hey,

I was getting this error when trying to define more than one PPA:  "Duplicate definition: Package[python-software-properties] is already defined"

I made some minor changes that have allowed me to get past this.

Thanks,
Scott
