### PR TITLE
Avoid duplicate definition of the python-software-properties package

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,7 +4,10 @@ class apt {
 	$root = '/etc/apt'
 	$provider = '/usr/bin/apt-get'
 
-  package { "python-software-properties": }
+    # Check if not already defined, before declaring the package
+    if ! defined(Package["python-software-properties"]) {
+        package { "python-software-properties": }
+    }
 
 	file { "sources.list":
 		name => "${root}/sources.list",


### PR DESCRIPTION
Just check if the python-software-properties package is not already defined before defining it.
