### PR TITLE
Install Package[python-software-properties] only if not already defined

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,8 +4,12 @@ class apt {
 	$root = '/etc/apt'
 	$provider = '/usr/bin/apt-get'
 
-  package { "python-software-properties": }
-
+  if !defined(Package["python-software-properties"]) {
+    package { "python-software-properties":
+      ensure => installed,
+    }
+  }
+  
 	file { "sources.list":
 		name => "${root}/sources.list",
 		ensure => present,

--- a/manifests/source.pp
+++ b/manifests/source.pp
@@ -41,10 +41,18 @@ define apt::source(
 	}
 
 	if $key != false {
-		exec { "/usr/bin/apt-key adv --keyserver ${key_server} --recv-keys ${key}":
-			unless => "/usr/bin/apt-key list | grep ${key}",
-			before => File["${name}.list"],
-		}
+	  if $key =~ /^http:\/\/.+/ {
+      exec { "curl $key | /usr/bin/apt-key add - ":
+        unless => "/usr/bin/apt-key list | grep -i ${name}",  # look for $name in keys  
+        before => File["${name}.list"],
+        provider => "shell",
+      }
+	  } else {
+  		exec { "/usr/bin/apt-key adv --keyserver ${key_server} --recv-keys ${key}":
+  			unless => "/usr/bin/apt-key list | grep ${key}",
+  			before => File["${name}.list"],
+  		}
+    }
 	}
 
 }


### PR DESCRIPTION
This was needed to interoperate with:
https://github.com/portertech/puppet-mongodb/blob/master/manifests/init.pp
